### PR TITLE
Add missing imports for Flask

### DIFF
--- a/test/test_HPLeftHandMockServer_flask.py
+++ b/test/test_HPLeftHandMockServer_flask.py
@@ -5,6 +5,7 @@ import string
 import argparse
 from werkzeug.exceptions import default_exceptions
 from werkzeug.exceptions import HTTPException
+from flask import Flask, request, make_response, session, abort, Response
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-debug", help="Turn on http debugging",


### PR DESCRIPTION
Running unit tests against the mock LHOS server fails due
to missing Flask imports.
